### PR TITLE
Update createNewDevice_buttons.json

### DIFF
--- a/fmx/createNewDevice_buttons.json
+++ b/fmx/createNewDevice_buttons.json
@@ -76,7 +76,7 @@
     "prio": 20,
     "actions": [
         {
-        "type": "link",
+        "type": "secondary",
         "btnText": "Start now",
         "link": ""
         }


### PR DESCRIPTION
Set the type for Start now action to "secodary" instead of "link".

https://github.com/Blynk-Technologies/dash/issues/38035